### PR TITLE
Change apiDomain to gumroad.com instead of api.gumroad.com

### DIFF
--- a/src/Provider/Gumroad.php
+++ b/src/Provider/Gumroad.php
@@ -30,7 +30,7 @@ class Gumroad extends AbstractProvider
      *
      * @var string
      */
-    public $apiDomain = 'https://api.gumroad.com';
+    public $apiDomain = 'https://gumroad.com';
 
     /**
      * Get authorization URL to begin OAuth flow


### PR DESCRIPTION
both endpoints work the same, but since the official repo in ruby uses the non api url I have updated my library to match. (https://github.com/gumroad/omniauth-gumroad/blob/master/lib/omniauth/strategies/gumroad.rb#L10)