### PR TITLE
fixes #5: Profile data is extracted from the JSON *user* field

### DIFF
--- a/src/Provider/Gumroad.php
+++ b/src/Provider/Gumroad.php
@@ -120,6 +120,6 @@ class Gumroad extends AbstractProvider
      */
     protected function createResourceOwner(array $response, AccessToken $token)
     {
-        return new GumroadResourceOwner($response);
+        return new GumroadResourceOwner($response['user']);
     }
 }

--- a/test/src/Provider/GumroadTest.php
+++ b/test/src/Provider/GumroadTest.php
@@ -106,7 +106,7 @@ class GumroadTest extends \PHPUnit\Framework\TestCase
         $postResponse->shouldReceive('getStatusCode')->andReturn(200);
 
         $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
-        $userResponse->shouldReceive('getBody')->andReturn('{"bio": "'.$bio.'", "facebook_profile": "'.$facebook_profile.'", "name": "'.$name.'", "twitter_handle": "'.$twitter_handle.'", "user_id": "'.$user_id.'", "email": "'.$email.'", "url": "'.$url.'"}');
+        $userResponse->shouldReceive('getBody')->andReturn('{"success": true, "user": {"bio": "'.$bio.'", "facebook_profile": "'.$facebook_profile.'", "name": "'.$name.'", "twitter_handle": "'.$twitter_handle.'", "user_id": "'.$user_id.'", "email": "'.$email.'", "url": "'.$url.'"}}');
         $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
         $userResponse->shouldReceive('getStatusCode')->andReturn(200);
 


### PR DESCRIPTION
As per https://gumroad.com/api#user the profile is wrapped into the `user` field.